### PR TITLE
Packet Driver : Corrected Coding error

### DIFF
--- a/spin/packet_driver.spin
+++ b/spin/packet_driver.spin
@@ -75,7 +75,7 @@ PUB startx(mbox, rxpin, txpin, mode, baudrate, rxsiz, txsiz, buffs) : okay
   stopx(mbox)
 
   ' compute the ticks per bit from the baudrate
-  baudrate := clkfreq / baudrate
+  bitticks := clkfreq / baudrate
 
   ' start the driver cog
   okay := long[mbox][4] := cognew(@entry, @mbox) + 1


### PR DESCRIPTION
There is a problem where this driver fails when used with a 10MHz clock. It may be that this coding error is responsible. I dont have the resources currently to test this. 
"bitticks" holds the value of how many ticks represent 1 bit and i think is used to adjust the driver to work with different clock frequencies.
This is as i have shown it in the program this driver is derived from. "Full Duplex Serial Driver v1.1 Extended"

I am new to all this so dont know if right place for this.
But if somebody could create a proploader.exe for windows so I can test this I would be greatful.