### PR TITLE
Modification to make fast loader work on Raspberry Pi serial port. Te…

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -321,7 +321,11 @@ static BoardConfig *GetDefaultConfiguration(void)
         defaultConfig = NewBoardConfig(NULL, DEF_BOARD);
         SetConfigField(defaultConfig, "baudrate",                   "115200");
         SetConfigField(defaultConfig, "loader-baud-rate",           "115200");
+#ifdef RASPBERRY_PI
+        SetConfigField(defaultConfig, "fast-loader-baud-rate",      "1000000");
+#else
         SetConfigField(defaultConfig, "fast-loader-baud-rate",      "921600");
+#endif
         SetConfigField(defaultConfig, "rxpin",                      "31");
         SetConfigField(defaultConfig, "txpin",                      "30");
         SetConfigField(defaultConfig, "sdspi-do",                   "22");

--- a/src/serial_posix.c
+++ b/src/serial_posix.c
@@ -195,7 +195,7 @@ int OpenSerial(const char *port, int baud, SERIAL **pSerial)
     sparams = serial->oldParams;
     
     /* set raw input */
-#ifdef MACOSX
+#if defined(MACOSX) || defined(RASPBERRY_PI)
     cfmakeraw(&sparams);
     sparams.c_cc[VTIME] = 0;
     sparams.c_cc[VMIN] = 1;
@@ -305,7 +305,7 @@ int SetSerialBaud(SERIAL *serial, int baud)
     chk("tcgetattr", tcgetattr(serial->fd, &sparams));
     
     /* set raw input */
-#ifdef MACOSX
+#if defined(MACOSX) || defined(RASPBERRY_PI)
     chk("cfsetspeed", cfsetspeed(&sparams, tbaud));
 #else
     chk("cfsetispeed", cfsetispeed(&sparams, tbaud));


### PR DESCRIPTION
…sted to work very reliably at 500Kbps and mostly reliably at 1Mbps (sometimes stepping down to 500K) on a Raspberry Pi Zero.

For background, see #50 